### PR TITLE
Fix description textarea id

### DIFF
--- a/views/campgrounds/edit.ejs
+++ b/views/campgrounds/edit.ejs
@@ -29,7 +29,7 @@
             </div>
             <div class="mb-3">
                 <label class="form-label" for="description">Description</label>
-                <textarea class="form-control" type="text" name="campground[description]" id="location" required><%= campground.description %></textarea>
+                <textarea class="form-control" type="text" name="campground[description]" id="description" required><%= campground.description %></textarea>
                 <div class="valid-feedback">
                     Looks good!
                 </div>

--- a/views/campgrounds/new.ejs
+++ b/views/campgrounds/new.ejs
@@ -29,7 +29,7 @@
             </div>
             <div class="mb-3">
                 <label class="form-label" for="description">Description</label>
-                <textarea class="form-control" type="text" name="campground[description]" id="location" required></textarea>
+                <textarea class="form-control" type="text" name="campground[description]" id="description" required></textarea>
                 <div class="valid-feedback">
                     Looks good!
                 </div>


### PR DESCRIPTION
## Summary
- update textarea id to `description` in the new campground form
- update textarea id to `description` in the edit campground form

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6855ff2c227c832893c461731c21fc63